### PR TITLE
Add WithLimit option

### DIFF
--- a/gogrouptest/group.go
+++ b/gogrouptest/group.go
@@ -57,7 +57,7 @@ func noParallel(ctx context.Context) bool {
 	return noparallel
 }
 
-func startForTest(ctx context.Context, funcs []func(context.Context) error, option internal.GroupOptions) func() error {
+func startForTest(ctx context.Context, funcs []func(context.Context) error, option internal.Options) func() error {
 	if !noParallel(ctx) {
 		return internal.DefaultStart(ctx, funcs, option)
 	}

--- a/gogrouptest/group.go
+++ b/gogrouptest/group.go
@@ -57,9 +57,9 @@ func noParallel(ctx context.Context) bool {
 	return noparallel
 }
 
-func startForTest(ctx context.Context, funcs []func(context.Context) error, _ internal.GroupOptions) func() error {
+func startForTest(ctx context.Context, funcs []func(context.Context) error, option internal.GroupOptions) func() error {
 	if !noParallel(ctx) {
-		return internal.DefaultStart(ctx, funcs, internal.GroupOptions{})
+		return internal.DefaultStart(ctx, funcs, option)
 	}
 
 	p := pool.New().WithContext(ctx).WithCancelOnError()

--- a/gogrouptest/group.go
+++ b/gogrouptest/group.go
@@ -57,7 +57,7 @@ func noParallel(ctx context.Context) bool {
 	return noparallel
 }
 
-func startForTest(ctx context.Context, funcs []func(context.Context) error) func() error {
+func startForTest(ctx context.Context, funcs []func(context.Context) error, _ ...internal.Option) func() error {
 	if !noParallel(ctx) {
 		return internal.DefaultStart(ctx, funcs)
 	}

--- a/gogrouptest/group.go
+++ b/gogrouptest/group.go
@@ -57,9 +57,9 @@ func noParallel(ctx context.Context) bool {
 	return noparallel
 }
 
-func startForTest(ctx context.Context, funcs []func(context.Context) error, _ ...internal.Option) func() error {
+func startForTest(ctx context.Context, funcs []func(context.Context) error, _ internal.GroupOptions) func() error {
 	if !noParallel(ctx) {
-		return internal.DefaultStart(ctx, funcs)
+		return internal.DefaultStart(ctx, funcs, internal.GroupOptions{})
 	}
 
 	p := pool.New().WithContext(ctx).WithCancelOnError()

--- a/group.go
+++ b/group.go
@@ -25,17 +25,22 @@ func (g *Group) Add(f func(context.Context) error) {
 	g.mu.Unlock()
 }
 
-func (g *Group) start(ctx context.Context, opts ...internal.Option) func() error {
+func (g *Group) start(ctx context.Context, opts ...GroupOption) func() error {
 	g.mu.Lock()
 	funcs := slices.Clone(g.funcs)
 	g.mu.Unlock()
 
-	return internal.Start(ctx, funcs, opts...)
+	o := internal.GroupOptions{}
+	for _, opt := range opts {
+		opt.apply(&o)
+	}
+
+	return internal.Start(ctx, funcs, o)
 }
 
 // Run calls all registered functions in different goroutines.
-func (g *Group) Run(ctx context.Context, opts ...internal.Option) error {
-	return g.start(ctx)()
+func (g *Group) Run(ctx context.Context, opts ...GroupOption) error {
+	return g.start(ctx, opts...)()
 }
 
 // Start calls the function in new goroutine and returns a wait function.

--- a/group.go
+++ b/group.go
@@ -25,12 +25,12 @@ func (g *Group) Add(f func(context.Context) error) {
 	g.mu.Unlock()
 }
 
-func (g *Group) start(ctx context.Context, opts ...GroupOption) func() error {
+func (g *Group) start(ctx context.Context, opts ...Option) func() error {
 	g.mu.Lock()
 	funcs := slices.Clone(g.funcs)
 	g.mu.Unlock()
 
-	o := internal.GroupOptions{}
+	o := internal.Options{}
 	for _, opt := range opts {
 		opt.apply(&o)
 	}
@@ -39,7 +39,7 @@ func (g *Group) start(ctx context.Context, opts ...GroupOption) func() error {
 }
 
 // Run calls all registered functions in different goroutines.
-func (g *Group) Run(ctx context.Context, opts ...GroupOption) error {
+func (g *Group) Run(ctx context.Context, opts ...Option) error {
 	return g.start(ctx, opts...)()
 }
 

--- a/group_option.go
+++ b/group_option.go
@@ -1,0 +1,16 @@
+package gogroup
+
+// GroupOption is an option to configure [(*Group).Run] behaviour.
+type Option func(*groupOptions) error
+
+type groupOptions struct {
+	limit int
+}
+
+// WithLimit sets the maximum number of goroutines used to run the functions.
+func WithLimit(limit int) Option {
+	return func(o *groupOptions) error {
+		o.limit = limit
+		return nil
+	}
+}

--- a/group_option.go
+++ b/group_option.go
@@ -1,16 +1,11 @@
 package gogroup
 
-// GroupOption is an option to configure [(*Group).Run] behaviour.
-type Option func(*groupOptions) error
-
-type groupOptions struct {
-	limit int
-}
+import "github.com/newmo-oss/gogroup/internal"
 
 // WithLimit sets the maximum number of goroutines used to run the functions. Ignored if n < 1.
-func WithLimit(n int) Option {
-	return func(o *groupOptions) error {
-		o.limit = n
+func WithLimit(n int) internal.Option {
+	return func(o *internal.GroupOptions) error {
+		o.Limit = n
 		return nil
 	}
 }

--- a/group_option.go
+++ b/group_option.go
@@ -2,10 +2,20 @@ package gogroup
 
 import "github.com/newmo-oss/gogroup/internal"
 
+// GroupOption is an option to configure [(*Group).Run] behaviour.
+type GroupOption interface {
+	apply(*internal.GroupOptions)
+}
+
 // WithLimit sets the maximum number of goroutines used to run the functions. Ignored if n < 1.
-func WithLimit(n int) internal.Option {
-	return func(o *internal.GroupOptions) error {
-		o.Limit = n
-		return nil
-	}
+func WithLimit(n int) GroupOption {
+	return withLimitOption{limit: n}
+}
+
+type withLimitOption struct {
+	limit int
+}
+
+func (wo withLimitOption) apply(o *internal.GroupOptions) {
+	o.Limit = wo.limit
 }

--- a/group_option.go
+++ b/group_option.go
@@ -7,10 +7,10 @@ type groupOptions struct {
 	limit int
 }
 
-// WithLimit sets the maximum number of goroutines used to run the functions.
-func WithLimit(limit int) Option {
+// WithLimit sets the maximum number of goroutines used to run the functions. Ignored if n < 1.
+func WithLimit(n int) Option {
 	return func(o *groupOptions) error {
-		o.limit = limit
+		o.limit = n
 		return nil
 	}
 }

--- a/group_option.go
+++ b/group_option.go
@@ -2,20 +2,22 @@ package gogroup
 
 import "github.com/newmo-oss/gogroup/internal"
 
-// GroupOption is an option to configure [(*Group).Run] behaviour.
-type GroupOption interface {
-	apply(*internal.GroupOptions)
+// Option is an option to configure [(*Group).Run] behaviour.
+type Option interface {
+	apply(*internal.Options)
 }
+
+type optionFunc func(*internal.Options)
+
+func (f optionFunc) apply(opts *internal.Options) {
+	f(opts)
+}
+
+var _ Option = optionFunc(nil)
 
 // WithLimit sets the maximum number of goroutines used to run the functions. Ignored if n < 1.
-func WithLimit(n int) GroupOption {
-	return withLimitOption{limit: n}
-}
-
-type withLimitOption struct {
-	limit int
-}
-
-func (wo withLimitOption) apply(o *internal.GroupOptions) {
-	o.Limit = wo.limit
+func WithLimit(n int) Option {
+	return optionFunc(func(opts *internal.Options) {
+		opts.Limit = n
+	})
 }

--- a/internal/group.go
+++ b/internal/group.go
@@ -9,11 +9,11 @@ import (
 
 var Start = DefaultStart
 
-type GroupOptions struct {
+type Options struct {
 	Limit int
 }
 
-func DefaultStart(ctx context.Context, funcs []func(context.Context) error, option GroupOptions) func() error {
+func DefaultStart(ctx context.Context, funcs []func(context.Context) error, option Options) func() error {
 	p := pool.New().WithContext(ctx).WithCancelOnError()
 
 	if option.Limit > 0 {

--- a/internal/group.go
+++ b/internal/group.go
@@ -9,21 +9,25 @@ import (
 
 var Start = DefaultStart
 
-func DefaultStart(ctx context.Context, funcs []func(context.Context) error) func() error {
-	p := pool.New().WithContext(ctx).WithCancelOnError()
-	for _, f := range funcs {
-		p.Go(func(ctx context.Context) (rerr error) {
-			if r := panics.Try(func() { rerr = f(ctx) }); r != nil {
-				return r.AsError()
-			}
-			return rerr
-		})
-	}
-	return p.Wait // return method value
+// GroupOption is an option to configure [(*Group).Run] behaviour.
+type Option func(*GroupOptions) error
+
+type GroupOptions struct {
+	Limit int
 }
 
-func StartWithLimit(ctx context.Context, funcs []func(context.Context) error, limit int) func() error {
-	p := pool.New().WithContext(ctx).WithCancelOnError().WithMaxGoroutines(limit)
+func DefaultStart(ctx context.Context, funcs []func(context.Context) error, opts ...Option) func() error {
+	var o GroupOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	p := pool.New().WithContext(ctx).WithCancelOnError()
+
+	if o.Limit > 0 {
+		p = p.WithMaxGoroutines(o.Limit)
+	}
+
 	for _, f := range funcs {
 		p.Go(func(ctx context.Context) (rerr error) {
 			if r := panics.Try(func() { rerr = f(ctx) }); r != nil {

--- a/internal/group.go
+++ b/internal/group.go
@@ -9,23 +9,15 @@ import (
 
 var Start = DefaultStart
 
-// GroupOption is an option to configure [(*Group).Run] behaviour.
-type Option func(*GroupOptions) error
-
 type GroupOptions struct {
 	Limit int
 }
 
-func DefaultStart(ctx context.Context, funcs []func(context.Context) error, opts ...Option) func() error {
-	var o GroupOptions
-	for _, opt := range opts {
-		opt(&o)
-	}
-
+func DefaultStart(ctx context.Context, funcs []func(context.Context) error, option GroupOptions) func() error {
 	p := pool.New().WithContext(ctx).WithCancelOnError()
 
-	if o.Limit > 0 {
-		p = p.WithMaxGoroutines(o.Limit)
+	if option.Limit > 0 {
+		p = p.WithMaxGoroutines(option.Limit)
 	}
 
 	for _, f := range funcs {


### PR DESCRIPTION
This pull request introduces configurable options for the `Group` struct, allowing for more flexible behavior, including limiting the number of goroutines used to execute functions. The most significant changes include adding a new `groupOptions` struct, implementing a `WithLimit` option to set a maximum goroutine limit, and modifying the `Run` method to accept these options.